### PR TITLE
Update APT41 - remove a line

### DIFF
--- a/APT41
+++ b/APT41
@@ -65,7 +65,6 @@ https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,38,MD5,849a
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,38,MD5,ba08b593250c3ca5c13f56e2ca97d85e
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,38,MD5,f8c89ccd8937f2b760e6706738210744
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,38,MD5,5b26f5c7c367d5e976aaba320965cc7f
-https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,42,CVE,CVE-2019-3369
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,43,CVE,CVE-2019-3396
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,43,CVE,CVE-2012-0158
 https://www.fireeye.com/content/dam/collateral/en/rpt-apt41-2019.pdf,43,CVE,CVE-2015-1641


### PR DESCRIPTION
This is due a typo in the report, where it uses 3396 in one place (correct) and 3369 in another (incorrect).